### PR TITLE
Revamp sidebar with collapsible navigation

### DIFF
--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -188,47 +188,303 @@
         display: flex;
         align-items: stretch;
         width: 100%;
+        gap: clamp(1rem, 3vw, 2.5rem);
       }
 
-      aside.sidebar {
-        width: 250px;
+      .vertical-sidebar {
+        --sidebar-expanded: 16.875rem;
+        --sidebar-collapsed: 3.35rem;
+        --sidebar-item: 2.5rem;
+        --sidebar-radius: 1rem;
+        --sidebar-frame: 0.5rem;
+        --sidebar-border: rgba(15, 94, 240, 0.08);
+        --sidebar-hover: rgba(15, 94, 240, 0.12);
+        --sidebar-active: rgba(15, 94, 240, 0.18);
+        --sidebar-focus: rgba(15, 94, 240, 0.22);
+        --sidebar-shadow: 0 20px 45px rgba(15, 94, 240, 0.12);
+        display: flex;
+        inline-size: var(--sidebar-expanded);
+        padding-block: clamp(1rem, 2.5vw, 1.5rem);
+        flex: 0 0 auto;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) {
+        inline-size: var(--sidebar-collapsed);
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .sidebar__link {
+        justify-content: center;
+        padding-inline: 0;
+      }
+
+      .vertical-sidebar input[type="checkbox"] {
+        display: none;
+      }
+
+      .vertical-sidebar nav {
         background: var(--surface);
-        border-right: 1px solid rgba(15, 94, 240, 0.12);
-        padding: 1.5rem 1rem;
+        border: 1px solid var(--sidebar-border);
+        border-radius: calc(var(--sidebar-radius) + var(--sidebar-frame));
+        box-shadow: var(--sidebar-shadow);
         display: flex;
         flex-direction: column;
-        gap: 1.5rem;
+        flex: 0 0 auto;
+        min-inline-size: var(--sidebar-collapsed);
+        padding: var(--sidebar-frame);
+        overflow: hidden;
+        transition: flex-basis 280ms ease;
       }
 
-      .sidebar h2 {
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--muted);
+      .vertical-sidebar :checked ~ nav {
+        flex-basis: var(--sidebar-expanded);
+      }
+
+      .vertical-sidebar :not(:checked) ~ nav {
+        flex-basis: var(--sidebar-collapsed);
+      }
+
+      .vertical-sidebar header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.25rem 0.35rem 0.35rem;
+      }
+
+      .vertical-sidebar .sidebar__toggle-container {
+        display: flex;
+        justify-content: flex-end;
+        min-block-size: var(--sidebar-item);
+      }
+
+      .vertical-sidebar .nav__toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        inline-size: var(--sidebar-item);
+        block-size: var(--sidebar-item);
+        border-radius: calc(var(--sidebar-radius) - var(--sidebar-frame));
+        border: none;
+        background: transparent;
+        outline: 2px solid transparent;
+        outline-offset: -2px;
+        transition: outline-color 200ms ease, background 200ms ease;
+      }
+
+      .vertical-sidebar .nav__toggle:hover,
+      .vertical-sidebar .nav__toggle:focus-visible {
+        background: rgba(15, 94, 240, 0.1);
+        outline-color: var(--brand);
+      }
+
+      .vertical-sidebar .toggle--icons {
+        inline-size: 100%;
+        block-size: 100%;
+        display: grid;
+        place-items: center;
+        position: relative;
+      }
+
+      .vertical-sidebar .toggle-svg-icon {
+        grid-area: 1 / 1;
+        fill: var(--muted);
+        transition: opacity 180ms ease, fill 180ms ease;
+      }
+
+      .vertical-sidebar figure {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
         margin: 0;
+        padding-inline: 0.35rem;
       }
 
-      .sidebar nav ul {
+      .vertical-sidebar .sidebar__avatar {
+        inline-size: clamp(2.5rem, 6vw, 3.25rem);
+        aspect-ratio: 1;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(15, 94, 240, 0.85), rgba(10, 68, 173, 0.95));
+        display: grid;
+        place-items: center;
+        font-weight: 600;
+        font-size: 1.1rem;
+        color: #fff;
+      }
+
+      .vertical-sidebar figcaption {
+        text-align: center;
+        color: var(--muted);
+      }
+
+      .vertical-sidebar .user-id {
+        font-weight: 600;
+        color: var(--text);
+        font-size: 0.95rem;
+      }
+
+      .vertical-sidebar .user-role {
+        font-size: 0.8rem;
+        letter-spacing: 0.02em;
+      }
+
+      .vertical-sidebar .sidebar__wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding: 0.35rem;
+      }
+
+      .vertical-sidebar .sidebar__list {
         list-style: none;
         margin: 0;
         padding: 0;
         display: flex;
         flex-direction: column;
-        gap: 0.35rem;
+        gap: 0.25rem;
       }
 
-      .sidebar nav a {
-        padding: 0.55rem 0.75rem;
-        border-radius: 0.65rem;
+      .vertical-sidebar .sidebar__item {
+        border-radius: calc(var(--sidebar-radius) - var(--sidebar-frame));
+      }
+
+      .vertical-sidebar .item--heading {
+        min-block-size: 1.5rem;
+        display: flex;
+        align-items: flex-end;
+      }
+
+      .vertical-sidebar .sidebar__item--heading {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
         color: var(--muted);
-        transition: all 0.2s ease;
+        margin: 0 0 0.35rem 0;
+        transition: color 200ms ease;
       }
 
-      .sidebar nav a:hover,
-      .sidebar nav a:focus {
-        background: rgba(15, 94, 240, 0.08);
+      .vertical-sidebar .sidebar__list:has(.sidebar__link:hover) .sidebar__item--heading,
+      .vertical-sidebar .sidebar__list:has(.sidebar__link:focus-visible) .sidebar__item--heading {
+        color: var(--text);
+      }
+
+      .vertical-sidebar .sidebar__link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        inline-size: 100%;
+        block-size: var(--sidebar-item);
+        padding-inline: 0.6rem;
+        border-radius: inherit;
+        color: var(--muted);
+        background: transparent;
+        border: none;
+        font: inherit;
+        text-align: left;
+        transition: background 200ms ease, color 200ms ease;
+        cursor: pointer;
+      }
+
+      .vertical-sidebar .sidebar__link .icon {
+        inline-size: 1.5rem;
+        block-size: 1.5rem;
+        display: grid;
+        place-items: center;
+      }
+
+      .vertical-sidebar .sidebar__link .icon svg {
+        inline-size: 1.05rem;
+        block-size: 1.05rem;
+        fill: currentColor;
+      }
+
+      .vertical-sidebar .sidebar__link .text {
+        font-weight: 500;
+        font-size: 0.9rem;
+        color: inherit;
+        pointer-events: none;
+      }
+
+      .vertical-sidebar .sidebar__link:hover,
+      .vertical-sidebar .sidebar__link:focus-visible {
+        background: var(--sidebar-hover);
         color: var(--brand);
         outline: none;
+      }
+
+      .vertical-sidebar .sidebar__link.is-active {
+        background: var(--sidebar-active);
+        color: var(--brand);
+        font-weight: 600;
+      }
+
+      .vertical-sidebar .sidebar__link.is-active .text {
+        color: inherit;
+      }
+
+      .vertical-sidebar .sidebar__link:active {
+        background: var(--sidebar-focus);
+        color: var(--brand-dark);
+      }
+
+      .vertical-sidebar .sidebar__form {
+        margin: 0;
+        display: flex;
+      }
+
+      .vertical-sidebar .sidebar__form .sidebar__link {
+        width: 100%;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .toggle--open,
+      .vertical-sidebar:has(:checked) .toggle--close {
+        opacity: 0;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .sidebar__item--heading,
+      .vertical-sidebar:not(:has(:checked)) figcaption,
+      .vertical-sidebar:not(:has(:checked)) .text {
+        opacity: 0;
+      }
+
+      .vertical-sidebar:has(:checked) .sidebar__item--heading,
+      .vertical-sidebar:has(:checked) figcaption,
+      .vertical-sidebar:has(:checked) .text {
+        transition: opacity 220ms ease 120ms;
+      }
+
+      .vertical-sidebar [data-tooltip]::before {
+        content: attr(data-tooltip);
+        position: fixed;
+        translate: calc(var(--sidebar-item) * 1.35) calc(var(--sidebar-item) * 0.1);
+        border-radius: calc(var(--sidebar-radius) - var(--sidebar-frame));
+        padding: 0.4rem 0.75rem;
+        color: #fff;
+        background: rgba(15, 37, 64, 0.95);
+        box-shadow: 0 12px 22px rgba(15, 37, 64, 0.35);
+        opacity: 0;
+        pointer-events: none;
+        scale: 0.75;
+        transform-origin: left center;
+        font-size: 0.85rem;
+        font-weight: 500;
+        transition: opacity 220ms ease, scale 220ms ease;
+        z-index: 99;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .sidebar__link:hover[data-tooltip]::before,
+      .vertical-sidebar:not(:has(:checked)) .sidebar__link:focus-visible[data-tooltip]::before {
+        opacity: 1;
+        scale: 1;
+      }
+
+      .vertical-sidebar .sidebar__footer {
+        margin-top: auto;
+        padding-top: 0.5rem;
+        border-top: 1px dashed var(--sidebar-border);
+      }
+
+      .vertical-sidebar .sidebar__footer .sidebar__link {
+        font-size: 0.85rem;
       }
 
       main {
@@ -645,15 +901,18 @@
           flex-direction: column;
         }
 
-        aside.sidebar {
-          width: 100%;
-          flex-direction: row;
-          gap: 1rem;
-          overflow-x: auto;
+        .vertical-sidebar {
+          inline-size: 100%;
+          padding-block: 1rem;
         }
 
-        .sidebar nav ul {
-          flex-direction: row;
+        .vertical-sidebar nav {
+          width: 100%;
+          flex-basis: 100% !important;
+        }
+
+        .vertical-sidebar [data-tooltip]::before {
+          display: none;
         }
       }
     </style>
@@ -683,29 +942,182 @@
     </nav>
     <div class="layout">
       {% if user.is_authenticated %}
-        <aside class="sidebar">
-          <div>
-            <h2>Navegación</h2>
-            <nav>
-                {% with active_app=request.resolver_match.app_name %}
-                  
-                    <ul class="nav-links">
-                      <li>
-                        <a href="{% url 'clients:list' %}" class="{% if active_app == 'clients' %}active{% endif %}">Clientes</a>
-                      </li>
-                      <li>
-                        <a href="{% url 'inventory:list' %}" class="{% if active_app == 'inventory' %}active{% endif %}">Inventario</a>
-                      </li>
-                      <li>
-                        <a href="{% url 'quotes:list' %}" class="{% if active_app == 'quotes' %}active{% endif %}">Cotizaciones</a>
-                      </li>
-                      <li>
-                        <a href="{% url 'reports:list' %}" class="{% if active_app == 'reports' %}active{% endif %}">Reportes</a>
-                      </li>
-              </ul>
+        <aside class="vertical-sidebar">
+          <input
+            type="checkbox"
+            role="switch"
+            id="sidebar-toggle"
+            class="vertical-sidebar__checkbox"
+            checked
+            aria-label="Contraer menú lateral"
+          />
+          <nav aria-label="Navegación secundaria">
+            <header>
+              <div class="sidebar__toggle-container">
+                <label
+                  tabindex="0"
+                  for="sidebar-toggle"
+                  id="label-for-sidebar-toggle"
+                  class="nav__toggle"
+                  aria-label="Alternar menú lateral"
+                >
+                  <span class="toggle--icons" aria-hidden="true">
+                    <svg
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      class="toggle-svg-icon toggle--open"
+                    >
+                      <path
+                        d="M3 5a1 1 0 1 0 0 2h18a1 1 0 1 0 0-2zM2 12a1 1 0 0 1 1-1h18a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1M2 18a1 1 0 0 1 1-1h18a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1"
+                      ></path>
+                    </svg>
+                    <svg
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      class="toggle-svg-icon toggle--close"
+                    >
+                      <path
+                        d="M18.707 6.707a1 1 0 0 0-1.414-1.414L12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 1 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12z"
+                      ></path>
+                    </svg>
+                  </span>
+                </label>
+              </div>
+              <figure>
+                <div class="sidebar__avatar" aria-hidden="true">
+                  {{ user.get_full_name|default:user.username|first|upper }}
+                </div>
+                <figcaption>
+                  <p class="user-id">{{ user.get_full_name|default:user.username }}</p>
+                  <p class="user-role">{{ user.email|default:"Cuenta interna" }}</p>
+                </figcaption>
+              </figure>
+            </header>
+            <section class="sidebar__wrapper">
+              {% with active_app=request.resolver_match.app_name %}
+                <ul class="sidebar__list list--primary">
+                  <li class="sidebar__item item--heading">
+                    <h2 class="sidebar__item--heading">Navegación</h2>
+                  </li>
+                  <li class="sidebar__item">
+                    <a
+                      href="{% url 'clients:list' %}"
+                      class="sidebar__link {% if active_app == 'clients' %}is-active{% endif %}"
+                      data-tooltip="Clientes"
+                      {% if active_app == 'clients' %}aria-current="page"{% endif %}
+                    >
+                      <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" fill="currentColor">
+                          <path d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1z"></path>
+                          <path fill-rule="evenodd" d="M11 7a3 3 0 1 0 0-6 3 3 0 0 0 0 6"></path>
+                          <path d="M5.216 14A2.238 2.238 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A5.88 5.88 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1z"></path>
+                          <path d="M4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5"></path>
+                        </svg>
+                      </span>
+                      <span class="text">Clientes</span>
+                    </a>
+                  </li>
+                  <li class="sidebar__item">
+                    <a
+                      href="{% url 'inventory:list' %}"
+                      class="sidebar__link {% if active_app == 'inventory' %}is-active{% endif %}"
+                      data-tooltip="Inventario"
+                      {% if active_app == 'inventory' %}aria-current="page"{% endif %}
+                    >
+                      <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" fill="currentColor">
+                          <path d="M8.186 1.113a1 1 0 0 0-.372 0L1.54 2.6A1 1 0 0 0 1 3.562V6.5l6-1.5v-4l.186-.387z"></path>
+                          <path d="M9 5v-4l5.46 1.487A1 1 0 0 1 15 3.45V6.5l-6-1.5z"></path>
+                          <path d="M0 8.5V12a1 1 0 0 0 .757.97l6 1.5a1 1 0 0 0 .486 0l6-1.5A1 1 0 0 0 14 12V8.5l-6 1.5z"></path>
+                        </svg>
+                      </span>
+                      <span class="text">Inventario</span>
+                    </a>
+                  </li>
+                  <li class="sidebar__item">
+                    <a
+                      href="{% url 'quotes:list' %}"
+                      class="sidebar__link {% if active_app == 'quotes' %}is-active{% endif %}"
+                      data-tooltip="Cotizaciones"
+                      {% if active_app == 'quotes' %}aria-current="page"{% endif %}
+                    >
+                      <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" fill="currentColor">
+                          <path d="M3 1a2 2 0 0 0-2 2v11.5a.5.5 0 0 0 .79.407L4.5 13h8a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2z"></path>
+                          <path d="M5 4.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5m0 2A.5.5 0 0 1 5.5 6h3a.5.5 0 0 1 0 1h-3A.5.5 0 0 1 5 6.5"></path>
+                        </svg>
+                      </span>
+                      <span class="text">Cotizaciones</span>
+                    </a>
+                  </li>
+                  <li class="sidebar__item">
+                    <a
+                      href="{% url 'reports:list' %}"
+                      class="sidebar__link {% if active_app == 'reports' %}is-active{% endif %}"
+                      data-tooltip="Reportes"
+                      {% if active_app == 'reports' %}aria-current="page"{% endif %}
+                    >
+                      <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 16 16" fill="currentColor">
+                          <path d="M10 2.5a.5.5 0 0 1 .5-.5h3.5A1.5 1.5 0 0 1 15.5 3.5v10a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 13.5v-10A1.5 1.5 0 0 1 2 2h3.5a.5.5 0 0 1 .5.5V5h4z"></path>
+                          <path d="M11 14V4H6V2H2a.5.5 0 0 0-.5.5V5h3a.5.5 0 0 1 .5.5V14z"></path>
+                          <path d="M4 9h1v3H4zm3-2h1v5H7zm3 1h1v4h-1z"></path>
+                        </svg>
+                      </span>
+                      <span class="text">Reportes</span>
+                    </a>
+                  </li>
+                </ul>
+                <div class="sidebar__footer">
+                  <ul class="sidebar__list list--secondary">
+                    <li class="sidebar__item item--heading">
+                      <h2 class="sidebar__item--heading">Cuenta</h2>
+                    </li>
+                    <li class="sidebar__item">
+                      <a
+                        href="{% url 'accounts:profile' %}"
+                        class="sidebar__link"
+                        data-tooltip="Mis datos"
+                      >
+                        <span class="icon" aria-hidden="true">
+                          <svg viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0"></path>
+                            <path
+                              fill-rule="evenodd"
+                              d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"
+                            ></path>
+                          </svg>
+                        </span>
+                        <span class="text">Mis datos</span>
+                      </a>
+                    </li>
+                    <li class="sidebar__item">
+                      <form method="post" action="{% url 'logout' %}" class="sidebar__form">
+                        {% csrf_token %}
+                        <button type="submit" class="sidebar__link" data-tooltip="Cerrar sesión">
+                          <span class="icon" aria-hidden="true">
+                            <svg viewBox="0 0 16 16" fill="currentColor">
+                              <path
+                                fill-rule="evenodd"
+                                d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"
+                              ></path>
+                              <path
+                                fill-rule="evenodd"
+                                d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"
+                              ></path>
+                            </svg>
+                          </span>
+                          <span class="text">Salir</span>
+                        </button>
+                      </form>
+                    </li>
+                  </ul>
+                </div>
               {% endwith %}
-            </nav>
-          </div>
+            </section>
+          </nav>
         </aside>
       {% endif %}
       <main>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -215,6 +215,26 @@
       .vertical-sidebar:not(:has(:checked)) .sidebar__link {
         justify-content: center;
         padding-inline: 0;
+        gap: 0;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .sidebar__link .text {
+        inline-size: 0;
+        block-size: 0;
+        overflow: hidden;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .sidebar__toggle-container {
+        justify-content: center;
+        padding-inline: 0;
+      }
+
+      .vertical-sidebar:has(:checked) .sidebar__toggle-container {
+        justify-content: flex-end;
+      }
+
+      .vertical-sidebar:not(:has(:checked)) .nav__toggle {
+        margin-inline: auto;
       }
 
       .vertical-sidebar input[type="checkbox"] {


### PR DESCRIPTION
## Summary
- replace the legacy sidebar with a collapsible vertical navigation adapted to the CoreQuote brand
- add inline SVG icons, tooltips, and account actions that match the new sidebar interaction model
- refresh the sidebar styling rules to support compact and expanded layouts while keeping the rest of the UI consistent

## Testing
- python backend/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ed7a87d0d08320999f2e3564db28a8