### PR TITLE
feat: show inventory metrics and price guidance

### DIFF
--- a/backend/config/views.py
+++ b/backend/config/views.py
@@ -8,6 +8,62 @@ from quotes.models import QuoteItem
 
 
 LOW_STOCK_THRESHOLD = 5
+THOUSAND = Decimal("1000")
+
+
+def strip_trailing_zeros(value: Decimal) -> str:
+    """Return a decimal as a string without superfluous trailing zeros."""
+
+    value_str = format(value, "f")
+    if "." in value_str:
+        value_str = value_str.rstrip("0").rstrip(".")
+    return value_str
+
+
+def format_currency(amount) -> str:
+    """Format a decimal amount as currency with two decimals."""
+
+    try:
+        decimal_amount = Decimal(amount)
+    except (InvalidOperation, TypeError):
+        decimal_amount = Decimal("0")
+
+    quantized = decimal_amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    sign = "-" if quantized < 0 else ""
+    absolute_str = f"{abs(quantized):,.2f}"
+    return f"{sign}${absolute_str}"
+
+
+def format_compact_currency(amount) -> str:
+    """Return a compact currency representation (e.g. 1.2k, 3.4M)."""
+
+    try:
+        decimal_amount = Decimal(amount)
+    except (InvalidOperation, TypeError):
+        decimal_amount = Decimal("0")
+
+    if abs(decimal_amount) < THOUSAND:
+        return format_currency(decimal_amount)
+
+    suffixes = ["", "k", "M", "B", "T"]
+    index = 0
+    value = abs(decimal_amount)
+
+    while value >= THOUSAND and index < len(suffixes) - 1:
+        value /= THOUSAND
+        index += 1
+
+    rounded = value.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
+    if rounded >= THOUSAND and index < len(suffixes) - 1:
+        value = rounded / THOUSAND
+        index += 1
+        rounded = value.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
+    number_str = strip_trailing_zeros(rounded)
+    sign = "-" if decimal_amount < 0 else ""
+
+    return f"{sign}${number_str}{suffixes[index]}"
 
 
 def home(request):
@@ -65,13 +121,19 @@ def home(request):
             "total_products": total_products,
             "total_stock": total_stock,
             "inventory_value": inventory_value,
+            "inventory_value_display": format_compact_currency(inventory_value),
+            "inventory_value_detail": format_currency(inventory_value),
             "low_stock_threshold": LOW_STOCK_THRESHOLD,
             "low_stock_total": low_stock_total,
             "low_stock_preview": low_stock_preview,
             "extra_low_stock": max(low_stock_total - len(low_stock_preview), 0),
             "total_revenue": total_revenue,
+            "total_revenue_detail": format_currency(total_revenue),
             "total_cost": total_cost,
+            "total_cost_detail": format_currency(total_cost),
             "total_profit": total_profit,
+            "total_profit_display": format_compact_currency(total_profit),
+            "total_profit_detail": format_currency(total_profit),
             "margin_percentage": margin_percentage,
             "has_data": total_products > 0 or total_revenue > 0,
         }

--- a/backend/config/views.py
+++ b/backend/config/views.py
@@ -1,7 +1,79 @@
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+
+from django.db.models import DecimalField, F, Sum
 from django.shortcuts import render
+
+from inventory.models import Item
+from quotes.models import QuoteItem
+
+
+LOW_STOCK_THRESHOLD = 5
 
 
 def home(request):
     """Landing page for CoreQuote."""
 
-    return render(request, "home.html")
+    context = {}
+
+    if request.user.is_authenticated:
+        items = Item.objects.filter(owner=request.user)
+        total_products = items.count()
+        totals = items.aggregate(
+            total_stock=Sum("stock"),
+            inventory_value=Sum(
+                F("stock") * F("cost"),
+                output_field=DecimalField(max_digits=18, decimal_places=2),
+            ),
+        )
+        total_stock = totals.get("total_stock") or 0
+        inventory_value = totals.get("inventory_value") or Decimal("0")
+
+        low_stock_queryset = items.filter(stock__lte=LOW_STOCK_THRESHOLD).order_by(
+            "stock", "name"
+        )
+        low_stock_total = low_stock_queryset.count()
+        low_stock_preview = list(low_stock_queryset[:5])
+
+        quote_items = QuoteItem.objects.filter(
+            quote__created_by=request.user, quote__deleted__isnull=True
+        )
+        quote_totals = quote_items.aggregate(
+            total_revenue=Sum(
+                F("quantity") * F("unit_price"),
+                output_field=DecimalField(max_digits=18, decimal_places=2),
+            ),
+            total_cost=Sum(
+                F("quantity") * F("item__cost"),
+                output_field=DecimalField(max_digits=18, decimal_places=2),
+            ),
+        )
+
+        total_revenue = quote_totals.get("total_revenue") or Decimal("0")
+        total_cost = quote_totals.get("total_cost") or Decimal("0")
+        total_profit = total_revenue - total_cost
+
+        margin_percentage = Decimal("0")
+        if total_revenue:
+            try:
+                margin_percentage = (
+                    (total_profit / total_revenue) * Decimal("100")
+                ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+            except (InvalidOperation, ZeroDivisionError):
+                margin_percentage = Decimal("0")
+
+        context["metrics"] = {
+            "total_products": total_products,
+            "total_stock": total_stock,
+            "inventory_value": inventory_value,
+            "low_stock_threshold": LOW_STOCK_THRESHOLD,
+            "low_stock_total": low_stock_total,
+            "low_stock_preview": low_stock_preview,
+            "extra_low_stock": max(low_stock_total - len(low_stock_preview), 0),
+            "total_revenue": total_revenue,
+            "total_cost": total_cost,
+            "total_profit": total_profit,
+            "margin_percentage": margin_percentage,
+            "has_data": total_products > 0 or total_revenue > 0,
+        }
+
+    return render(request, "home.html", context)

--- a/backend/inventory/forms.py
+++ b/backend/inventory/forms.py
@@ -4,6 +4,14 @@ from .models import Item
 
 
 class ItemForm(forms.ModelForm):
+    def __init__(self, *args, owner=None, **kwargs):
+        self.owner = owner
+        super().__init__(*args, **kwargs)
+        if self.owner is None:
+            instance_owner = getattr(self.instance, "owner", None)
+            if instance_owner is not None:
+                self.owner = instance_owner
+
     class Meta:
         model = Item
         fields = ["sku", "name", "stock", "cost"]
@@ -19,3 +27,20 @@ class ItemForm(forms.ModelForm):
             "stock": "Inventario",
             "cost": "Costo unitario",
         }
+
+    def clean_sku(self):
+        sku = self.cleaned_data.get("sku")
+        owner = self.owner
+        if not sku or owner is None:
+            return sku
+
+        queryset = Item.objects.filter(owner=owner, sku__iexact=sku)
+        if self.instance.pk:
+            queryset = queryset.exclude(pk=self.instance.pk)
+
+        if queryset.exists():
+            raise forms.ValidationError(
+                "Ya existe un producto con este SKU. Ingresa un identificador diferente o edita el producto existente.",
+            )
+
+        return sku

--- a/backend/inventory/tests.py
+++ b/backend/inventory/tests.py
@@ -1,3 +1,66 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .forms import ItemForm
+from .models import Item
+
+
+class ItemFormTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="tester",
+            email="tester@example.com",
+            password="secret123",
+        )
+
+    def test_item_form_blocks_duplicate_sku_for_owner(self):
+        Item.objects.create(owner=self.user, sku="SKU-001", name="Base", stock=1, cost=1)
+
+        form = ItemForm(
+            data={"sku": "SKU-001", "name": "Otro", "stock": 5, "cost": "10.00"},
+            owner=self.user,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("sku", form.errors)
+        self.assertIn("Ya existe un producto con este SKU", form.errors["sku"][0])
+
+    def test_item_form_allows_same_sku_for_same_item(self):
+        item = Item.objects.create(owner=self.user, sku="SKU-002", name="Base", stock=1, cost=1)
+
+        form = ItemForm(
+            data={"sku": "SKU-002", "name": "Base", "stock": 10, "cost": "12.00"},
+            owner=self.user,
+            instance=item,
+        )
+
+        self.assertTrue(form.is_valid())
+
+
+class ItemCreateViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="creator",
+            email="creator@example.com",
+            password="secret123",
+        )
+
+    def test_htmx_duplicate_sku_shows_toast_error(self):
+        Item.objects.create(owner=self.user, sku="SKU-ABC", name="Registrado", stock=1, cost=1)
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("inventory:create"),
+            data={"sku": "SKU-ABC", "name": "Nuevo", "stock": 2, "cost": "3.50"},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("HX-Trigger", response)
+        triggers = json.loads(response["HX-Trigger"])
+        self.assertIn("toast", triggers)
+        self.assertEqual(triggers["toast"]["type"], "error")
+        self.assertIn("SKU", triggers["toast"]["message"])

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -1,6 +1,7 @@
 import json
 
 from django.contrib.auth.decorators import login_required
+from django.db import IntegrityError
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -13,12 +14,25 @@ def _is_htmx(request):
     return request.headers.get("HX-Request") == "true"
 
 
-def _render_item_form(request, form, item=None):
-    return render(
+def _render_item_form(request, form, item=None, hx_trigger=None):
+    response = render(
         request,
         "inventory/partials/item_form.html",
         {"form": form, "item": item},
     )
+    if hx_trigger:
+        response["HX-Trigger"] = json.dumps(hx_trigger)
+    return response
+
+
+def _first_form_error_message(form):
+    for errors in form.errors.values():
+        if errors:
+            return errors[0]
+    non_field_errors = form.non_field_errors()
+    if non_field_errors:
+        return non_field_errors[0]
+    return "Por favor corrige los errores en el formulario."
 
 
 @login_required
@@ -28,7 +42,7 @@ def item_list(request):
         "inventory/list.html",
         {
             "items": Item.objects.filter(owner=request.user).order_by("-created_at"),
-            "form": ItemForm(),
+            "form": ItemForm(owner=request.user),
         },
     )
 
@@ -38,9 +52,9 @@ def item_create(request):
     if request.method != "POST":
         if not _is_htmx(request):
             return redirect("inventory:list")
-        return _render_item_form(request, ItemForm())
+        return _render_item_form(request, ItemForm(owner=request.user))
 
-    form = ItemForm(request.POST)
+    form = ItemForm(request.POST, owner=request.user)
     if not form.is_valid():
         if not _is_htmx(request):
             return render(
@@ -51,14 +65,48 @@ def item_create(request):
                     "form": form,
                 },
             )
-        return _render_item_form(request, form)
+        return _render_item_form(
+            request,
+            form,
+            hx_trigger={
+                "toast": {
+                    "message": _first_form_error_message(form),
+                    "type": "error",
+                }
+            },
+        )
 
     item = form.save(commit=False)
     item.owner = request.user
-    item.save()
+    try:
+        item.save()
+    except IntegrityError:
+        form.add_error(
+            "sku",
+            "Ya existe un producto con este SKU. Ingresa un identificador diferente o edita el producto existente.",
+        )
+        if not _is_htmx(request):
+            return render(
+                request,
+                "inventory/list.html",
+                {
+                    "items": Item.objects.filter(owner=request.user).order_by("-created_at"),
+                    "form": form,
+                },
+            )
+        return _render_item_form(
+            request,
+            form,
+            hx_trigger={
+                "toast": {
+                    "message": _first_form_error_message(form),
+                    "type": "error",
+                }
+            },
+        )
     if not _is_htmx(request):
         return redirect("inventory:list")
-    form = ItemForm()
+    form = ItemForm(owner=request.user)
     form_html = render_to_string(
         "inventory/partials/item_form.html",
         {"form": form},
@@ -90,12 +138,16 @@ def item_update(request, pk):
     if request.method == "GET":
         if not _is_htmx(request):
             return redirect("inventory:list")
-        return _render_item_form(request, ItemForm(instance=item), item)
+        return _render_item_form(
+            request,
+            ItemForm(instance=item, owner=request.user),
+            item,
+        )
 
     if request.method != "POST":
         return HttpResponseNotAllowed(["GET", "POST"])
 
-    form = ItemForm(request.POST, instance=item)
+    form = ItemForm(request.POST, instance=item, owner=request.user)
     if not form.is_valid():
         if not _is_htmx(request):
             return render(
@@ -106,15 +158,51 @@ def item_update(request, pk):
                     "form": form,
                 },
             )
-        return _render_item_form(request, form, item)
+        return _render_item_form(
+            request,
+            form,
+            item,
+            hx_trigger={
+                "toast": {
+                    "message": _first_form_error_message(form),
+                    "type": "error",
+                }
+            },
+        )
 
-    item = form.save()
+    try:
+        item = form.save()
+    except IntegrityError:
+        form.add_error(
+            "sku",
+            "Ya existe un producto con este SKU. Ingresa un identificador diferente o edita el producto existente.",
+        )
+        if not _is_htmx(request):
+            return render(
+                request,
+                "inventory/list.html",
+                {
+                    "items": Item.objects.filter(owner=request.user).order_by("-created_at"),
+                    "form": form,
+                },
+            )
+        return _render_item_form(
+            request,
+            form,
+            item,
+            hx_trigger={
+                "toast": {
+                    "message": _first_form_error_message(form),
+                    "type": "error",
+                }
+            },
+        )
     if not _is_htmx(request):
         return redirect("inventory:list")
 
     form_html = render_to_string(
         "inventory/partials/item_form.html",
-        {"form": ItemForm()},
+        {"form": ItemForm(owner=request.user)},
         request=request,
     )
     row_html = render_to_string(

--- a/backend/quotes/forms.py
+++ b/backend/quotes/forms.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 
 from clients.models import Client
@@ -34,3 +36,10 @@ class QuoteItemForm(forms.Form):
         if user is not None:
             queryset = Item.objects.filter(owner=user).order_by("name")
         self.fields["item"].queryset = queryset
+        cost_map = {str(item.pk): format(item.cost, "f") for item in queryset}
+        self.fields["item"].widget.attrs.update(
+            {
+                "data-cost-map": json.dumps(cost_map),
+                "data-margin": "0.60",
+            }
+        )

--- a/backend/quotes/templates/quotes/partials/quote_item_row.html
+++ b/backend/quotes/templates/quotes/partials/quote_item_row.html
@@ -19,6 +19,7 @@
     {% if form.unit_price.errors %}
       <p class="error">{{ form.unit_price.errors|join:', ' }}</p>
     {% endif %}
+    <span class="form-hint" data-price-hint hidden></span>
   </td>
   <td class="field remove">
     <button type="button" class="link danger" data-remove-item>Quitar</button>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -15,6 +15,11 @@
         --muted: #64748b;
       }
 
+      html {
+        width: 100%;
+        overflow-x: hidden;
+      }
+
       * {
         box-sizing: border-box;
       }
@@ -27,6 +32,7 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
+        overflow-x: hidden;
       }
 
       a {

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -635,6 +635,17 @@
         gap: 0.35rem;
       }
 
+      [data-price-hint] {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 0.78rem;
+        color: var(--muted);
+      }
+
+      [data-price-hint][hidden] {
+        display: none;
+      }
+
       .form-row {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -896,6 +907,216 @@
         line-height: 1.6;
         color: var(--muted);
         font-size: 1.05rem;
+      }
+
+      .dashboard-insights {
+        margin-top: 2.5rem;
+        display: grid;
+        gap: 2rem;
+      }
+
+      .metrics-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .metric-card {
+        background: var(--surface);
+        border-radius: 1.2rem;
+        padding: 1.4rem 1.6rem;
+        box-shadow: 0 22px 50px rgba(15, 94, 240, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .metric-card--highlight {
+        border: 1px solid rgba(34, 197, 94, 0.35);
+        box-shadow: 0 26px 60px rgba(34, 197, 94, 0.2);
+      }
+
+      .metric-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .metric-label {
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+
+      .metric-value {
+        font-size: clamp(1.8rem, 4vw, 2.4rem);
+        font-weight: 700;
+        margin: 0;
+        color: var(--text);
+      }
+
+      .metric-caption {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .metric-tooltip {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.6rem;
+        height: 1.6rem;
+        border-radius: 999px;
+        background: rgba(15, 94, 240, 0.12);
+        color: var(--brand);
+        font-weight: 600;
+        font-size: 0.85rem;
+        cursor: pointer;
+      }
+
+      .metric-tooltip:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(15, 94, 240, 0.25);
+      }
+
+      .metric-tooltip::after {
+        content: attr(data-tooltip);
+        position: absolute;
+        bottom: calc(100% + 0.6rem);
+        left: 50%;
+        transform: translateX(-50%);
+        background: var(--surface);
+        color: var(--text);
+        border-radius: 0.9rem;
+        padding: 0.75rem 1rem;
+        box-shadow: 0 22px 55px rgba(15, 94, 240, 0.2);
+        min-width: 220px;
+        max-width: 280px;
+        font-size: 0.8rem;
+        line-height: 1.5;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+        white-space: pre-line;
+        z-index: 15;
+      }
+
+      .metric-tooltip::before {
+        content: "";
+        position: absolute;
+        bottom: calc(100% + 0.3rem);
+        left: 50%;
+        transform: translateX(-50%);
+        border: 6px solid transparent;
+        border-top-color: var(--surface);
+        opacity: 0;
+        transition: opacity 0.2s ease;
+      }
+
+      .metric-tooltip:hover::after,
+      .metric-tooltip:focus::after,
+      .metric-tooltip:hover::before,
+      .metric-tooltip:focus::before {
+        opacity: 1;
+      }
+
+      .inventory-status {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .status-card {
+        background: var(--surface);
+        border-radius: 1.2rem;
+        padding: 1.6rem;
+        box-shadow: 0 22px 50px rgba(15, 94, 240, 0.08);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .status-card.warning {
+        border-left: 4px solid #f59e0b;
+      }
+
+      .status-card.success {
+        border-left: 4px solid #22c55e;
+      }
+
+      .status-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .status-card__header h2 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .status-card p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      .status-card ul {
+        margin: 0;
+        padding-left: 1.25rem;
+        color: var(--muted);
+      }
+
+      .status-card li {
+        margin-bottom: 0.35rem;
+      }
+
+      .status-card li:last-child {
+        margin-bottom: 0;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.2rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: rgba(15, 94, 240, 0.12);
+        color: var(--brand);
+      }
+
+      .status-card.warning .status-pill {
+        background: rgba(245, 158, 11, 0.15);
+        color: #c2410c;
+      }
+
+      .status-card.success .status-pill {
+        background: rgba(34, 197, 94, 0.18);
+        color: #15803d;
+      }
+
+      .empty-state {
+        background: var(--surface);
+        border-radius: 1.2rem;
+        padding: 2rem;
+        box-shadow: 0 22px 50px rgba(15, 94, 240, 0.08);
+        text-align: center;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .empty-state h2 {
+        margin: 0;
+      }
+
+      .empty-state p {
+        margin: 0;
+        color: var(--muted);
       }
 
       .primary-action {
@@ -1360,6 +1581,72 @@
             const getRows = () =>
               Array.from(wrapper.querySelectorAll("[data-item-row]"));
 
+            const parseCostMap = (select) => {
+              if (!select) return {};
+              try {
+                const raw = select.dataset.costMap || "{}";
+                return JSON.parse(raw);
+              } catch (error) {
+                console.error("No se pudo leer el mapa de costos", error);
+                return {};
+              }
+            };
+
+            const getMargin = (select) => {
+              if (!select) return 0.6;
+              const margin = Number.parseFloat(select.dataset.margin);
+              return Number.isFinite(margin) ? margin : 0.6;
+            };
+
+            const formatCurrency = (value) => {
+              if (!Number.isFinite(value)) return "";
+              try {
+                return new Intl.NumberFormat("es-MX", {
+                  style: "currency",
+                  currency: "MXN",
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                }).format(value);
+              } catch (error) {
+                return value.toFixed(2);
+              }
+            };
+
+            const updatePriceHint = (row) => {
+              if (!row) return;
+              const select = row.querySelector("select");
+              const hint = row.querySelector("[data-price-hint]");
+              const priceInput = row.querySelector('input[name$="-unit_price"]');
+              if (!select || !hint) return;
+
+              const margin = getMargin(select);
+              const costMap = parseCostMap(select);
+              const cost = Number.parseFloat(costMap?.[select.value]);
+              const marginPercent = Math.round(margin * 100);
+              const defaultMessage = `Selecciona un producto para ver un precio sugerido (utilidad del ${marginPercent}%).`;
+
+              if (!Number.isFinite(cost) || cost <= 0) {
+                hint.textContent = defaultMessage;
+                hint.hidden = false;
+                if (priceInput) {
+                  priceInput.removeAttribute("placeholder");
+                }
+                return;
+              }
+
+              const suggested = cost * (1 + margin);
+              const formatted = formatCurrency(suggested);
+              hint.textContent = `Sugerido: ${formatted} (utilidad del ${marginPercent}%)`;
+              hint.hidden = false;
+              if (priceInput && !priceInput.value) {
+                priceInput.placeholder = formatted;
+              }
+            };
+
+            const refreshHints = () => {
+              getRows().forEach((row) => updatePriceHint(row));
+            };
+
             function addItem() {
               if (!template) return;
               const index = parseInt(totalFormsInput.value || "0", 10);
@@ -1404,6 +1691,7 @@
               if (!rows.length && template) {
                 addItem();
               }
+              refreshHints();
             }
 
             function removeItem(button) {
@@ -1435,6 +1723,13 @@
                 event.preventDefault();
                 addItem();
               }
+            });
+
+            wrapper.addEventListener("change", (event) => {
+              const select = event.target.closest?.("select");
+              if (!select) return;
+              const row = select.closest?.("[data-item-row]");
+              updatePriceHint(row);
             });
 
             renumber();

--- a/backend/templates/home.html
+++ b/backend/templates/home.html
@@ -52,24 +52,24 @@
             <div class="metric-card__header">
               <span class="metric-label">Valor de material</span>
             </div>
-            <p class="metric-value">${{ metrics.inventory_value|floatformat:2 }}</p>
+            <p class="metric-value" title="{{ metrics.inventory_value_detail }}">{{ metrics.inventory_value_display }}</p>
             <p class="metric-caption">Costo estimado del inventario actual</p>
           </article>
 
           <article class="metric-card metric-card--highlight">
             <div class="metric-card__header">
               <span class="metric-label">Ganancia estimada</span>
-              {% with tooltip_revenue=metrics.total_revenue|floatformat:2 tooltip_cost=metrics.total_cost|floatformat:2 tooltip_margin=metrics.margin_percentage|floatformat:1 %}
+              {% with tooltip_profit=metrics.total_profit_detail tooltip_revenue=metrics.total_revenue_detail tooltip_cost=metrics.total_cost_detail tooltip_margin=metrics.margin_percentage|floatformat:1 %}
                 <span
                   class="metric-tooltip"
                   tabindex="0"
                   aria-label="Detalle de ganancias"
-                  data-tooltip="Valor cotizado: ${{ tooltip_revenue }}&#10;Costo estimado: ${{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
-                  title="Valor cotizado: ${{ tooltip_revenue }}&#10;Costo estimado: ${{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
+                  data-tooltip="Ganancia estimada: {{ tooltip_profit }}&#10;Valor cotizado: {{ tooltip_revenue }}&#10;Costo estimado: {{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
+                  title="Ganancia estimada: {{ tooltip_profit }}&#10;Valor cotizado: {{ tooltip_revenue }}&#10;Costo estimado: {{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
                 >?</span>
               {% endwith %}
             </div>
-            <p class="metric-value">${{ metrics.total_profit|floatformat:2 }}</p>
+            <p class="metric-value" title="{{ metrics.total_profit_detail }}">{{ metrics.total_profit_display }}</p>
             <p class="metric-caption">Margen promedio de {{ metrics.margin_percentage|floatformat:1 }}%</p>
           </article>
         </div>

--- a/backend/templates/home.html
+++ b/backend/templates/home.html
@@ -16,14 +16,112 @@
       cuenta. Si aún no tienes acceso, ponte en contacto con el administrador de
       CoreQuote.
     </p>
-    
+
       <a class="primary-action" href="{% url 'login' %}">Iniciar sesión</a>
     {% else %}
-    <h1>Bienvenido de nuevo, {{ user.get_full_name|default:user.username }}!</h1>  
-    
-      <p>Usa el menú de navegación para acceder a las diferentes secciones de la aplicación.</p>
-      <p>Si necesitas ayuda, consulta la documentación o contacta al soporte.</p>
-      <p>Mas adelante aqui se te mostraran las metricas de tus productos y cotizaciones</p>
+    <h1>Bienvenido de nuevo, {{ user.get_full_name|default:user.username }}!</h1>
+
+      <p>
+        Este es un resumen rápido del estado de tu inventario y de las cotizaciones
+        registradas. Usa los accesos del menú para actualizar productos o generar
+        nuevas propuestas.
+      </p>
     {% endif %}
   </section>
+  {% if user.is_authenticated %}
+    <section class="dashboard-insights">
+      {% if metrics.has_data %}
+        <div class="metrics-grid">
+          <article class="metric-card">
+            <div class="metric-card__header">
+              <span class="metric-label">Productos activos</span>
+            </div>
+            <p class="metric-value">{{ metrics.total_products }}</p>
+            <p class="metric-caption">SKU disponibles en el inventario</p>
+          </article>
+
+          <article class="metric-card">
+            <div class="metric-card__header">
+              <span class="metric-label">Unidades en inventario</span>
+            </div>
+            <p class="metric-value">{{ metrics.total_stock }}</p>
+            <p class="metric-caption">Existencias totales registradas</p>
+          </article>
+
+          <article class="metric-card">
+            <div class="metric-card__header">
+              <span class="metric-label">Valor de material</span>
+            </div>
+            <p class="metric-value">${{ metrics.inventory_value|floatformat:2 }}</p>
+            <p class="metric-caption">Costo estimado del inventario actual</p>
+          </article>
+
+          <article class="metric-card metric-card--highlight">
+            <div class="metric-card__header">
+              <span class="metric-label">Ganancia estimada</span>
+              {% with tooltip_revenue=metrics.total_revenue|floatformat:2 tooltip_cost=metrics.total_cost|floatformat:2 tooltip_margin=metrics.margin_percentage|floatformat:1 %}
+                <span
+                  class="metric-tooltip"
+                  tabindex="0"
+                  aria-label="Detalle de ganancias"
+                  data-tooltip="Valor cotizado: ${{ tooltip_revenue }}&#10;Costo estimado: ${{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
+                  title="Valor cotizado: ${{ tooltip_revenue }}&#10;Costo estimado: ${{ tooltip_cost }}&#10;Margen promedio: {{ tooltip_margin }}%"
+                >?</span>
+              {% endwith %}
+            </div>
+            <p class="metric-value">${{ metrics.total_profit|floatformat:2 }}</p>
+            <p class="metric-caption">Margen promedio de {{ metrics.margin_percentage|floatformat:1 }}%</p>
+          </article>
+        </div>
+      {% else %}
+        <div class="empty-state">
+          <h2>Aún no tienes datos para mostrar</h2>
+          <p>
+            Empieza registrando tus productos para calcular el valor del inventario y
+            generar cotizaciones con márgenes sugeridos.
+          </p>
+          <a class="primary-action" href="{% url 'inventory:create' %}">Registrar mi primer producto</a>
+        </div>
+      {% endif %}
+
+      <div class="inventory-status">
+        {% if metrics.low_stock_total %}
+          <article class="status-card warning">
+            <div class="status-card__header">
+              <h2>Productos con stock bajo</h2>
+              <span class="status-pill">{{ metrics.low_stock_total }}</span>
+            </div>
+            <p>
+              {% if metrics.low_stock_total == 1 %}
+                1 producto está por debajo del umbral de {{ metrics.low_stock_threshold }} unidades.
+              {% else %}
+                {{ metrics.low_stock_total }} productos están por debajo del umbral de {{ metrics.low_stock_threshold }} unidades.
+              {% endif %}
+            </p>
+            <ul>
+              {% for item in metrics.low_stock_preview %}
+                <li><strong>{{ item.name }}</strong> — {{ item.stock }} unidades en inventario</li>
+              {% endfor %}
+              {% if metrics.extra_low_stock %}
+                <li>… y {{ metrics.extra_low_stock }} más.</li>
+              {% endif %}
+            </ul>
+            <a class="link" href="{% url 'inventory:list' %}">Revisar inventario completo</a>
+          </article>
+        {% elif metrics.total_products %}
+          <article class="status-card success">
+            <div class="status-card__header">
+              <h2>Inventario al día</h2>
+              <span class="status-pill">OK</span>
+            </div>
+            <p>
+              Todos tus productos superan el umbral de {{ metrics.low_stock_threshold }} unidades. Mantén tus
+              existencias actualizadas para evitar quiebres de stock.
+            </p>
+            <a class="link" href="{% url 'inventory:list' %}">Ver inventario</a>
+          </article>
+        {% endif %}
+      </div>
+    </section>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- display inventory and quote performance metrics on the home dashboard, including low-stock alerts and profit details
- add subtle 60% margin price suggestions to the quote item form with front-end guidance
- refresh shared styles to support metrics cards, tooltips, and pricing hints

## Testing
- python backend/manage.py check *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68ef5f86c4088320beaf71ea74f8fef2