### PR TITLE
Enable editing of account details from profile

### DIFF
--- a/backend/accounts/forms.py
+++ b/backend/accounts/forms.py
@@ -40,6 +40,10 @@ class UserAccountForm(BaseStyledForm, forms.ModelForm):
             "email": forms.EmailInput(),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["first_name"].widget.attrs.setdefault("data-modal-focus", "true")
+
 
 class StyledPasswordChangeForm(BaseStyledForm, PasswordChangeForm):
     """Password change form with consistent styling."""
@@ -53,6 +57,7 @@ class StyledPasswordChangeForm(BaseStyledForm, PasswordChangeForm):
         self.fields["old_password"].widget.attrs["autocomplete"] = "current-password"
         self.fields["new_password1"].widget.attrs["autocomplete"] = "new-password"
         self.fields["new_password2"].widget.attrs["autocomplete"] = "new-password"
+        self.fields["old_password"].widget.attrs.setdefault("data-modal-focus", "true")
 
 
 class CompanyProfileForm(BaseStyledForm, forms.ModelForm):

--- a/backend/accounts/forms.py
+++ b/backend/accounts/forms.py
@@ -1,9 +1,61 @@
 from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import PasswordChangeForm
 
 from .models import CompanyProfile
 
 
-class CompanyProfileForm(forms.ModelForm):
+class BaseStyledForm:
+    """Mixin to apply consistent styling to form fields."""
+
+    def _apply_styling(self):
+        for field in self.fields.values():
+            classes = ["form-input"]
+            if isinstance(field.widget, forms.FileInput):
+                classes.append("file-input")
+            field.widget.attrs.setdefault("class", " ".join(classes))
+            if isinstance(field.widget, forms.PasswordInput):
+                field.widget.attrs.setdefault("autocomplete", "new-password")
+            field.widget.attrs.setdefault(
+                "placeholder", "Opcional" if field.required is False else ""
+            )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._apply_styling()
+
+
+class UserAccountForm(BaseStyledForm, forms.ModelForm):
+    """Allow users to update their account information except username."""
+
+    class Meta:
+        model = get_user_model()
+        fields = ["first_name", "last_name", "email"]
+        labels = {
+            "first_name": "Nombre",
+            "last_name": "Apellidos",
+            "email": "Correo electrónico",
+        }
+        widgets = {
+            "email": forms.EmailInput(),
+        }
+
+
+class StyledPasswordChangeForm(BaseStyledForm, PasswordChangeForm):
+    """Password change form with consistent styling."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Override default labels for clarity in Spanish.
+        self.fields["old_password"].label = "Contraseña actual"
+        self.fields["new_password1"].label = "Nueva contraseña"
+        self.fields["new_password2"].label = "Confirmar nueva contraseña"
+        self.fields["old_password"].widget.attrs["autocomplete"] = "current-password"
+        self.fields["new_password1"].widget.attrs["autocomplete"] = "new-password"
+        self.fields["new_password2"].widget.attrs["autocomplete"] = "new-password"
+
+
+class CompanyProfileForm(BaseStyledForm, forms.ModelForm):
     class Meta:
         model = CompanyProfile
         fields = [
@@ -18,11 +70,3 @@ class CompanyProfileForm(forms.ModelForm):
             "tax_address": forms.Textarea(attrs={"rows": 3}),
         }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for field in self.fields.values():
-            classes = ["form-input"]
-            if isinstance(field.widget, forms.FileInput):
-                classes.append("file-input")
-            field.widget.attrs.setdefault("class", " ".join(classes))
-            field.widget.attrs.setdefault("placeholder", "Opcional" if field.required is False else "")

--- a/backend/accounts/templates/accounts/profile.html
+++ b/backend/accounts/templates/accounts/profile.html
@@ -3,6 +3,56 @@
 {% block title %}Mi perfil fiscal | CoreQuote{% endblock %}
 
 {% block content %}
+  <style>
+    .modal-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.55);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 90;
+    }
+
+    .modal-dialog {
+      position: relative;
+      width: min(480px, 100%);
+      background: #ffffff;
+      border-radius: 1rem;
+      padding: clamp(1.75rem, 2vw + 1.25rem, 2.5rem);
+      box-shadow: 0 18px 55px rgba(15, 23, 42, 0.22);
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .modal-close {
+      position: absolute;
+      top: 0.85rem;
+      right: 0.85rem;
+      border: none;
+      background: rgba(148, 163, 184, 0.25);
+      width: 2.25rem;
+      height: 2.25rem;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      color: #0f172a;
+      cursor: pointer;
+      font-size: 1.25rem;
+      line-height: 1;
+    }
+
+    .modal-close:hover {
+      background: rgba(15, 94, 240, 0.12);
+      color: var(--brand);
+    }
+
+    body.modal-open {
+      overflow: hidden;
+    }
+  </style>
+
   <section class="card" style="max-width: 880px;">
     <h1>Identidad fiscal y branding</h1>
     <p style="color: var(--muted); max-width: 60ch;">
@@ -38,6 +88,23 @@
               <dd style="margin: 0.35rem 0 0;">{{ request.user.email|default:"No especificado" }}</dd>
             </div>
           </dl>
+
+          <div style="margin-top: 1.5rem; display: flex; gap: 0.75rem; flex-wrap: wrap;">
+            <button
+              type="button"
+              data-modal-target="account-modal"
+              style="padding: 0.6rem 1.35rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;"
+            >
+              Editar datos personales
+            </button>
+            <button
+              type="button"
+              data-modal-target="password-modal"
+              style="padding: 0.6rem 1.35rem; border-radius: 999px; border: 1px solid rgba(15, 94, 240, 0.35); background: #fff; color: var(--brand); font-weight: 600; cursor: pointer;"
+            >
+              Cambiar contraseña
+            </button>
+          </div>
         </section>
 
         <section>
@@ -52,99 +119,6 @@
           <p style="margin-top: 0.75rem; font-size: 0.85rem; color: var(--muted);">
             Sugerencia: usa un archivo PNG o SVG ligero (&lt; 1&nbsp;MB) para tiempos de carga rápidos.
           </p>
-        </section>
-
-        <section>
-          <h3 style="font-size: 0.95rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Información personal</h3>
-          <p style="margin: 0.75rem 0 1.25rem; color: var(--muted); font-size: 0.9rem;">
-            Actualiza tu nombre y correo de contacto. El nombre de usuario se mantiene sin cambios para conservar tus accesos.
-          </p>
-          <form method="post" style="display: grid; gap: 1rem;">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="update-account" />
-
-            {% if account_form.non_field_errors %}
-              <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
-                {{ account_form.non_field_errors|striptags }}
-              </div>
-            {% endif %}
-
-            <div>
-              <label for="{{ account_form.first_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nombre</label>
-              {{ account_form.first_name }}
-              {% if account_form.first_name.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.first_name.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <div>
-              <label for="{{ account_form.last_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Apellidos</label>
-              {{ account_form.last_name }}
-              {% if account_form.last_name.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.last_name.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <div>
-              <label for="{{ account_form.email.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Correo electrónico</label>
-              {{ account_form.email }}
-              {% if account_form.email.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.email.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <button type="submit" style="justify-self: start; padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;">
-              Guardar datos personales
-            </button>
-          </form>
-        </section>
-
-        <section>
-          <h3 style="font-size: 0.95rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Cambiar contraseña</h3>
-          <p style="margin: 0.75rem 0 1.25rem; color: var(--muted); font-size: 0.9rem;">
-            Utiliza esta sección para elegir una nueva contraseña segura. Necesitamos tu contraseña actual para confirmar tu identidad.
-          </p>
-          <form method="post" style="display: grid; gap: 1rem;">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="change-password" />
-
-            {% if password_form.non_field_errors %}
-              <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
-                {{ password_form.non_field_errors|striptags }}
-              </div>
-            {% endif %}
-
-            <div>
-              <label for="{{ password_form.old_password.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Contraseña actual</label>
-              {{ password_form.old_password }}
-              {% if password_form.old_password.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.old_password.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <div>
-              <label for="{{ password_form.new_password1.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nueva contraseña</label>
-              {{ password_form.new_password1 }}
-              {% if password_form.new_password1.help_text %}
-                <small style="display: block; margin-top: 0.35rem; color: var(--muted);">{{ password_form.new_password1.help_text|safe }}</small>
-              {% endif %}
-              {% if password_form.new_password1.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password1.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <div>
-              <label for="{{ password_form.new_password2.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Confirmar nueva contraseña</label>
-              {{ password_form.new_password2 }}
-              {% if password_form.new_password2.errors %}
-                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password2.errors|striptags }}</small>
-              {% endif %}
-            </div>
-
-            <button type="submit" style="justify-self: start; padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand-dark); color: #fff; font-weight: 600; cursor: pointer;">
-              Actualizar contraseña
-            </button>
-          </form>
         </section>
       </div>
 
@@ -214,4 +188,206 @@
       </form>
     </div>
   </section>
+
+  <div
+    class="modal-backdrop"
+    data-modal="account-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="account-modal-title"
+    {% if account_form.errors or account_form.non_field_errors %}data-open-on-load="true"{% endif %}
+    hidden
+  >
+    <div class="modal-dialog">
+      <button type="button" class="modal-close" data-modal-dismiss aria-label="Cerrar">
+        &times;
+      </button>
+      <div>
+        <h2 id="account-modal-title" style="font-size: 1.25rem; font-weight: 700; margin: 0;">Editar datos personales</h2>
+        <p style="margin: 0.75rem 0 0; color: var(--muted);">
+          Actualiza tu nombre y correo de contacto. Tu nombre de usuario se mantiene sin cambios para conservar el acceso.
+        </p>
+      </div>
+      <form method="post" style="display: grid; gap: 1rem;">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="update-account" />
+
+        {% if account_form.non_field_errors %}
+          <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
+            {{ account_form.non_field_errors|striptags }}
+          </div>
+        {% endif %}
+
+        <div>
+          <label for="{{ account_form.first_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nombre</label>
+          {{ account_form.first_name.as_widget(attrs={"data-modal-focus": "true"}) }}
+          {% if account_form.first_name.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.first_name.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ account_form.last_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Apellidos</label>
+          {{ account_form.last_name }}
+          {% if account_form.last_name.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.last_name.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ account_form.email.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Correo electrónico</label>
+          {{ account_form.email }}
+          {% if account_form.email.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.email.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
+          <button type="button" data-modal-dismiss style="padding: 0.65rem 1.3rem; border-radius: 999px; border: 1px solid rgba(15, 23, 42, 0.12); background: #fff; font-weight: 600; color: var(--muted); cursor: pointer;">
+            Cancelar
+          </button>
+          <button type="submit" style="padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;">
+            Guardar cambios
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div
+    class="modal-backdrop"
+    data-modal="password-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="password-modal-title"
+    {% if password_form.errors or password_form.non_field_errors %}data-open-on-load="true"{% endif %}
+    hidden
+  >
+    <div class="modal-dialog">
+      <button type="button" class="modal-close" data-modal-dismiss aria-label="Cerrar">
+        &times;
+      </button>
+      <div>
+        <h2 id="password-modal-title" style="font-size: 1.25rem; font-weight: 700; margin: 0;">Actualizar contraseña</h2>
+        <p style="margin: 0.75rem 0 0; color: var(--muted);">
+          Necesitamos tu contraseña actual para confirmar tu identidad antes de guardar una nueva contraseña segura.
+        </p>
+      </div>
+      <form method="post" style="display: grid; gap: 1rem;">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="change-password" />
+
+        {% if password_form.non_field_errors %}
+          <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
+            {{ password_form.non_field_errors|striptags }}
+          </div>
+        {% endif %}
+
+        <div>
+          <label for="{{ password_form.old_password.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Contraseña actual</label>
+          {{ password_form.old_password.as_widget(attrs={"data-modal-focus": "true"}) }}
+          {% if password_form.old_password.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.old_password.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ password_form.new_password1.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nueva contraseña</label>
+          {{ password_form.new_password1 }}
+          {% if password_form.new_password1.help_text %}
+            <small style="display: block; margin-top: 0.35rem; color: var(--muted);">{{ password_form.new_password1.help_text|safe }}</small>
+          {% endif %}
+          {% if password_form.new_password1.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password1.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ password_form.new_password2.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Confirmar nueva contraseña</label>
+          {{ password_form.new_password2 }}
+          {% if password_form.new_password2.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password2.errors|striptags }}</small>
+          {% endif %}
+        </div>
+
+        <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
+          <button type="button" data-modal-dismiss style="padding: 0.65rem 1.3rem; border-radius: 999px; border: 1px solid rgba(15, 23, 42, 0.12); background: #fff; font-weight: 600; color: var(--muted); cursor: pointer;">
+            Cancelar
+          </button>
+          <button type="submit" style="padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand-dark); color: #fff; font-weight: 600; cursor: pointer;">
+            Actualizar contraseña
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const body = document.body;
+      const openClass = "modal-open";
+      let activeTrigger = null;
+
+      const closeModal = (modal) => {
+        if (!modal) {
+          return;
+        }
+        modal.classList.remove("is-open");
+        modal.setAttribute("hidden", "");
+        if (!document.querySelector("[data-modal].is-open")) {
+          body.classList.remove(openClass);
+        }
+        if (activeTrigger) {
+          activeTrigger.focus();
+          activeTrigger = null;
+        }
+      };
+
+      const openModal = (modal, trigger = null) => {
+        if (!modal) {
+          return;
+        }
+        activeTrigger = trigger;
+        modal.removeAttribute("hidden");
+        modal.classList.add("is-open");
+        body.classList.add(openClass);
+        const focusTarget = modal.querySelector("[data-modal-focus]") || modal.querySelector("input, button, select, textarea");
+        if (focusTarget) {
+          focusTarget.focus();
+        }
+      };
+
+      document.querySelectorAll("[data-modal-target]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const modal = document.querySelector(`[data-modal="${button.dataset.modalTarget}"]`);
+          openModal(modal, button);
+        });
+      });
+
+      document.querySelectorAll("[data-modal]").forEach((modal) => {
+        modal.addEventListener("click", (event) => {
+          if (event.target === modal) {
+            closeModal(modal);
+          }
+        });
+
+        modal.querySelectorAll("[data-modal-dismiss]").forEach((button) => {
+          button.addEventListener("click", () => closeModal(modal));
+        });
+
+        if (modal.dataset.openOnLoad === "true") {
+          openModal(modal);
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          const opened = document.querySelector("[data-modal].is-open");
+          if (opened) {
+            closeModal(opened);
+          }
+        }
+      });
+    })();
+  </script>
 {% endblock %}

--- a/backend/accounts/templates/accounts/profile.html
+++ b/backend/accounts/templates/accounts/profile.html
@@ -48,6 +48,10 @@
       color: var(--brand);
     }
 
+    .modal-backdrop[hidden] {
+      display: none !important;
+    }
+
     body.modal-open {
       overflow: hidden;
     }
@@ -95,14 +99,7 @@
               data-modal-target="account-modal"
               style="padding: 0.6rem 1.35rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;"
             >
-              Editar datos personales
-            </button>
-            <button
-              type="button"
-              data-modal-target="password-modal"
-              style="padding: 0.6rem 1.35rem; border-radius: 999px; border: 1px solid rgba(15, 94, 240, 0.35); background: #fff; color: var(--brand); font-weight: 600; cursor: pointer;"
-            >
-              Cambiar contraseña
+              Gestionar cuenta
             </button>
           </div>
         </section>
@@ -196,6 +193,7 @@
     aria-modal="true"
     aria-labelledby="account-modal-title"
     {% if account_form.errors or account_form.non_field_errors %}data-open-on-load="true"{% endif %}
+    {% if account_form.errors or account_form.non_field_errors %}data-force-account-form="true"{% endif %}
     hidden
   >
     <div class="modal-dialog">
@@ -205,10 +203,43 @@
       <div>
         <h2 id="account-modal-title" style="font-size: 1.25rem; font-weight: 700; margin: 0;">Editar datos personales</h2>
         <p style="margin: 0.75rem 0 0; color: var(--muted);">
-          Actualiza tu nombre y correo de contacto. Tu nombre de usuario se mantiene sin cambios para conservar el acceso.
+          Consulta tus datos actuales y decide si deseas actualizar tu información o cambiar tu contraseña.
         </p>
       </div>
-      <form method="post" style="display: grid; gap: 1rem;">
+      <div data-account-step="overview" {% if account_form.errors or account_form.non_field_errors %}hidden{% endif %}>
+        <dl style="margin: 1rem 0 1.5rem; display: grid; gap: 0.85rem;">
+          <div>
+            <dt style="font-weight: 600; color: var(--muted);">Nombre de usuario</dt>
+            <dd style="margin: 0.35rem 0 0;">{{ request.user.username }}</dd>
+          </div>
+          <div>
+            <dt style="font-weight: 600; color: var(--muted);">Nombre completo</dt>
+            <dd style="margin: 0.35rem 0 0;">{{ request.user.get_full_name|default:"No especificado" }}</dd>
+          </div>
+          <div>
+            <dt style="font-weight: 600; color: var(--muted);">Correo electrónico</dt>
+            <dd style="margin: 0.35rem 0 0;">{{ request.user.email|default:"No especificado" }}</dd>
+          </div>
+        </dl>
+        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; justify-content: flex-end;">
+          <button
+            type="button"
+            data-account-edit
+            data-modal-focus
+            style="padding: 0.65rem 1.3rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;"
+          >
+            Editar datos
+          </button>
+          <button
+            type="button"
+            data-modal-switch="password-modal"
+            style="padding: 0.65rem 1.3rem; border-radius: 999px; border: 1px solid rgba(15, 94, 240, 0.35); background: #fff; color: var(--brand); font-weight: 600; cursor: pointer;"
+          >
+            Cambiar contraseña
+          </button>
+        </div>
+      </div>
+      <form method="post" style="display: grid; gap: 1rem;" data-account-step="form" {% if not account_form.errors and not account_form.non_field_errors %}hidden{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="action" value="update-account" />
 
@@ -242,9 +273,13 @@
           {% endif %}
         </div>
 
-        <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
-          <button type="button" data-modal-dismiss style="padding: 0.65rem 1.3rem; border-radius: 999px; border: 1px solid rgba(15, 23, 42, 0.12); background: #fff; font-weight: 600; color: var(--muted); cursor: pointer;">
-            Cancelar
+        <div style="display: flex; gap: 0.75rem; justify-content: flex-end; flex-wrap: wrap;">
+          <button
+            type="button"
+            data-account-cancel
+            style="padding: 0.65rem 1.3rem; border-radius: 999px; border: 1px solid rgba(148, 163, 184, 0.35); background: #fff; font-weight: 600; color: var(--muted); cursor: pointer;"
+          >
+            Volver
           </button>
           <button type="submit" style="padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;">
             Guardar cambios
@@ -328,17 +363,39 @@
       const openClass = "modal-open";
       let activeTrigger = null;
 
-      const closeModal = (modal) => {
+      const findFocusable = (container) => {
+        if (!container) {
+          return null;
+        }
+        const selectors =
+          "[data-modal-focus], button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled])";
+        const candidates = container.querySelectorAll(selectors);
+        for (const element of candidates) {
+          if (element.closest("[hidden]")) {
+            continue;
+          }
+          if (element.getAttribute("aria-hidden") === "true") {
+            continue;
+          }
+          return element;
+        }
+        return null;
+      };
+
+      const closeModal = (modal, { restoreFocus = true, preserveTrigger = false } = {}) => {
         if (!modal) {
           return;
         }
         modal.classList.remove("is-open");
         modal.setAttribute("hidden", "");
+        modal.dispatchEvent(new CustomEvent("modal:close"));
         if (!document.querySelector("[data-modal].is-open")) {
           body.classList.remove(openClass);
         }
-        if (activeTrigger) {
+        if (restoreFocus && activeTrigger) {
           activeTrigger.focus();
+        }
+        if (!preserveTrigger) {
           activeTrigger = null;
         }
       };
@@ -347,15 +404,86 @@
         if (!modal) {
           return;
         }
-        activeTrigger = trigger;
+        if (trigger) {
+          activeTrigger = trigger;
+        }
         modal.removeAttribute("hidden");
         modal.classList.add("is-open");
         body.classList.add(openClass);
-        const focusTarget = modal.querySelector("[data-modal-focus]") || modal.querySelector("input, button, select, textarea");
+        modal.dispatchEvent(new CustomEvent("modal:open"));
+        const focusTarget = findFocusable(modal);
         if (focusTarget) {
           focusTarget.focus();
         }
       };
+
+      const accountModal = document.querySelector('[data-modal="account-modal"]');
+      if (accountModal) {
+        const overviewStep = accountModal.querySelector('[data-account-step="overview"]');
+        const formStep = accountModal.querySelector('[data-account-step="form"]');
+        const editButton = accountModal.querySelector('[data-account-edit]');
+        const cancelButton = accountModal.querySelector('[data-account-cancel]');
+        const switchButtons = accountModal.querySelectorAll('[data-modal-switch]');
+
+        const setStep = (step) => {
+          if (!overviewStep || !formStep) {
+            return;
+          }
+          if (step === "form") {
+            overviewStep.setAttribute("hidden", "");
+            formStep.removeAttribute("hidden");
+          } else {
+            formStep.setAttribute("hidden", "");
+            overviewStep.removeAttribute("hidden");
+          }
+        };
+
+        const resetStep = () => {
+          if (accountModal.dataset.forceAccountForm === "true") {
+            setStep("form");
+          } else {
+            setStep("overview");
+          }
+        };
+
+        resetStep();
+
+        if (editButton) {
+          editButton.addEventListener("click", () => {
+            setStep("form");
+            const focusTarget = findFocusable(formStep);
+            if (focusTarget) {
+              focusTarget.focus();
+            }
+          });
+        }
+
+        if (cancelButton) {
+          cancelButton.addEventListener("click", () => {
+            setStep("overview");
+            const focusTarget = findFocusable(overviewStep) || findFocusable(accountModal);
+            if (focusTarget) {
+              focusTarget.focus();
+            }
+          });
+        }
+
+        switchButtons.forEach((button) => {
+          button.addEventListener("click", () => {
+            const targetModal = document.querySelector(`[data-modal="${button.dataset.modalSwitch}"]`);
+            if (!targetModal) {
+              return;
+            }
+            const sourceTrigger = activeTrigger;
+            closeModal(accountModal, { restoreFocus: false, preserveTrigger: true });
+            openModal(targetModal, sourceTrigger || button);
+          });
+        });
+
+        accountModal.addEventListener("modal:close", () => {
+          resetStep();
+        });
+      }
 
       document.querySelectorAll("[data-modal-target]").forEach((button) => {
         button.addEventListener("click", () => {

--- a/backend/accounts/templates/accounts/profile.html
+++ b/backend/accounts/templates/accounts/profile.html
@@ -220,7 +220,7 @@
 
         <div>
           <label for="{{ account_form.first_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nombre</label>
-          {{ account_form.first_name.as_widget(attrs={'data-modal-focus': 'true'}) }}
+          {{ account_form.first_name }}
           {% if account_form.first_name.errors %}
             <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.first_name.errors|striptags }}</small>
           {% endif %}
@@ -285,7 +285,7 @@
 
         <div>
           <label for="{{ password_form.old_password.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Contraseña actual</label>
-          {{ password_form.old_password.as_widget(attrs={'data-modal-focus': 'true'}) }}
+          {{ password_form.old_password }}
           {% if password_form.old_password.errors %}
             <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.old_password.errors|striptags }}</small>
           {% endif %}

--- a/backend/accounts/templates/accounts/profile.html
+++ b/backend/accounts/templates/accounts/profile.html
@@ -20,25 +20,27 @@
       </ul>
     {% endif %}
 
-    <div style="display: grid; grid-template-columns: minmax(220px, 280px) minmax(260px, 1fr); gap: 2rem; align-items: start; margin-top: 2rem;">
-      <div>
-        <h2 style="font-size: 1rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Resumen de la cuenta</h2>
-        <dl style="margin: 1rem 0 0; display: grid; gap: 1rem;">
-          <div>
-            <dt style="font-weight: 600; color: var(--muted);">Nombre de usuario</dt>
-            <dd style="margin: 0.35rem 0 0;">{{ request.user.username }}</dd>
-          </div>
-          <div>
-            <dt style="font-weight: 600; color: var(--muted);">Nombre completo</dt>
-            <dd style="margin: 0.35rem 0 0;">{{ request.user.get_full_name|default:"No especificado" }}</dd>
-          </div>
-          <div>
-            <dt style="font-weight: 600; color: var(--muted);">Correo electrónico</dt>
-            <dd style="margin: 0.35rem 0 0;">{{ request.user.email|default:"No especificado" }}</dd>
-          </div>
-        </dl>
+    <div style="display: grid; grid-template-columns: minmax(220px, 300px) minmax(260px, 1fr); gap: 2.5rem; align-items: start; margin-top: 2rem;">
+      <div style="display: grid; gap: 2.5rem; align-content: start;">
+        <section>
+          <h2 style="font-size: 1rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Resumen de la cuenta</h2>
+          <dl style="margin: 1rem 0 0; display: grid; gap: 1rem;">
+            <div>
+              <dt style="font-weight: 600; color: var(--muted);">Nombre de usuario</dt>
+              <dd style="margin: 0.35rem 0 0;">{{ request.user.username }}</dd>
+            </div>
+            <div>
+              <dt style="font-weight: 600; color: var(--muted);">Nombre completo</dt>
+              <dd style="margin: 0.35rem 0 0;">{{ request.user.get_full_name|default:"No especificado" }}</dd>
+            </div>
+            <div>
+              <dt style="font-weight: 600; color: var(--muted);">Correo electrónico</dt>
+              <dd style="margin: 0.35rem 0 0;">{{ request.user.email|default:"No especificado" }}</dd>
+            </div>
+          </dl>
+        </section>
 
-        <div style="margin-top: 2.5rem;">
+        <section>
           <h3 style="font-size: 0.95rem; font-weight: 600; color: var(--muted);">Logotipo actual</h3>
           {% if profile.logo %}
             <div style="margin-top: 0.75rem; padding: 1rem; border: 1px dashed rgba(15, 94, 240, 0.35); border-radius: 0.85rem; background: rgba(15, 94, 240, 0.04);">
@@ -50,70 +52,164 @@
           <p style="margin-top: 0.75rem; font-size: 0.85rem; color: var(--muted);">
             Sugerencia: usa un archivo PNG o SVG ligero (&lt; 1&nbsp;MB) para tiempos de carga rápidos.
           </p>
-        </div>
+        </section>
+
+        <section>
+          <h3 style="font-size: 0.95rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Información personal</h3>
+          <p style="margin: 0.75rem 0 1.25rem; color: var(--muted); font-size: 0.9rem;">
+            Actualiza tu nombre y correo de contacto. El nombre de usuario se mantiene sin cambios para conservar tus accesos.
+          </p>
+          <form method="post" style="display: grid; gap: 1rem;">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="update-account" />
+
+            {% if account_form.non_field_errors %}
+              <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
+                {{ account_form.non_field_errors|striptags }}
+              </div>
+            {% endif %}
+
+            <div>
+              <label for="{{ account_form.first_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nombre</label>
+              {{ account_form.first_name }}
+              {% if account_form.first_name.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.first_name.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <div>
+              <label for="{{ account_form.last_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Apellidos</label>
+              {{ account_form.last_name }}
+              {% if account_form.last_name.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.last_name.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <div>
+              <label for="{{ account_form.email.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Correo electrónico</label>
+              {{ account_form.email }}
+              {% if account_form.email.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.email.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <button type="submit" style="justify-self: start; padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;">
+              Guardar datos personales
+            </button>
+          </form>
+        </section>
+
+        <section>
+          <h3 style="font-size: 0.95rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em;">Cambiar contraseña</h3>
+          <p style="margin: 0.75rem 0 1.25rem; color: var(--muted); font-size: 0.9rem;">
+            Utiliza esta sección para elegir una nueva contraseña segura. Necesitamos tu contraseña actual para confirmar tu identidad.
+          </p>
+          <form method="post" style="display: grid; gap: 1rem;">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="change-password" />
+
+            {% if password_form.non_field_errors %}
+              <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
+                {{ password_form.non_field_errors|striptags }}
+              </div>
+            {% endif %}
+
+            <div>
+              <label for="{{ password_form.old_password.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Contraseña actual</label>
+              {{ password_form.old_password }}
+              {% if password_form.old_password.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.old_password.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <div>
+              <label for="{{ password_form.new_password1.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nueva contraseña</label>
+              {{ password_form.new_password1 }}
+              {% if password_form.new_password1.help_text %}
+                <small style="display: block; margin-top: 0.35rem; color: var(--muted);">{{ password_form.new_password1.help_text|safe }}</small>
+              {% endif %}
+              {% if password_form.new_password1.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password1.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <div>
+              <label for="{{ password_form.new_password2.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Confirmar nueva contraseña</label>
+              {{ password_form.new_password2 }}
+              {% if password_form.new_password2.errors %}
+                <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.new_password2.errors|striptags }}</small>
+              {% endif %}
+            </div>
+
+            <button type="submit" style="justify-self: start; padding: 0.65rem 1.4rem; border-radius: 999px; border: none; background: var(--brand-dark); color: #fff; font-weight: 600; cursor: pointer;">
+              Actualizar contraseña
+            </button>
+          </form>
+        </section>
       </div>
 
       <form method="post" enctype="multipart/form-data" style="display: grid; gap: 1.25rem;">
         {% csrf_token %}
+        <input type="hidden" name="action" value="update-company" />
 
-        {% if form.non_field_errors %}
+        {% if profile_form.non_field_errors %}
           <div style="padding: 0.75rem 1rem; border-radius: 0.75rem; background: rgba(220, 38, 38, 0.12); color: #b91c1c;">
-            {{ form.non_field_errors|striptags }}
+            {{ profile_form.non_field_errors|striptags }}
           </div>
         {% endif %}
 
         <div>
-          <label for="{{ form.legal_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Razón social</label>
-          {{ form.legal_name }}
+          <label for="{{ profile_form.legal_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Razón social</label>
+          {{ profile_form.legal_name }}
           <small style="display: block; margin-top: 0.3rem; color: var(--muted);">Nombre que se mostrará como emisor.</small>
-          {% if form.legal_name.errors %}
-            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.legal_name.errors|striptags }}</small>
+          {% if profile_form.legal_name.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.legal_name.errors|striptags }}</small>
           {% endif %}
         </div>
 
         <div style="display: grid; gap: 1.25rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));">
           <div>
-            <label for="{{ form.tax_id.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">RFC</label>
-            {{ form.tax_id }}
-            {% if form.tax_id.errors %}
-              <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.tax_id.errors|striptags }}</small>
+            <label for="{{ profile_form.tax_id.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">RFC</label>
+            {{ profile_form.tax_id }}
+            {% if profile_form.tax_id.errors %}
+              <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.tax_id.errors|striptags }}</small>
             {% endif %}
           </div>
           <div>
-            <label for="{{ form.contact_phone.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Teléfono</label>
-            {{ form.contact_phone }}
-            {% if form.contact_phone.errors %}
-              <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.contact_phone.errors|striptags }}</small>
+            <label for="{{ profile_form.contact_phone.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Teléfono</label>
+            {{ profile_form.contact_phone }}
+            {% if profile_form.contact_phone.errors %}
+              <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.contact_phone.errors|striptags }}</small>
             {% endif %}
           </div>
         </div>
 
         <div>
-          <label for="{{ form.tax_address.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Domicilio fiscal</label>
-          {{ form.tax_address }}
-          {% if form.tax_address.errors %}
-            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.tax_address.errors|striptags }}</small>
+          <label for="{{ profile_form.tax_address.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Domicilio fiscal</label>
+          {{ profile_form.tax_address }}
+          {% if profile_form.tax_address.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.tax_address.errors|striptags }}</small>
           {% endif %}
         </div>
 
         <div>
-          <label for="{{ form.contact_email.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Correo de contacto</label>
-          {{ form.contact_email }}
-          {% if form.contact_email.errors %}
-            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.contact_email.errors|striptags }}</small>
+          <label for="{{ profile_form.contact_email.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Correo de contacto</label>
+          {{ profile_form.contact_email }}
+          {% if profile_form.contact_email.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.contact_email.errors|striptags }}</small>
           {% endif %}
         </div>
 
         <div>
-          <label for="{{ form.logo.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Logotipo</label>
-          {{ form.logo }}
-          {% if form.logo.errors %}
-            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ form.logo.errors|striptags }}</small>
+          <label for="{{ profile_form.logo.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Logotipo</label>
+          {{ profile_form.logo }}
+          {% if profile_form.logo.errors %}
+            <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ profile_form.logo.errors|striptags }}</small>
           {% endif %}
         </div>
 
         <button type="submit" style="justify-self: start; padding: 0.7rem 1.5rem; border-radius: 999px; border: none; background: var(--brand); color: #fff; font-weight: 600; cursor: pointer;">
-          Guardar cambios
+          Guardar cambios fiscales
         </button>
       </form>
     </div>

--- a/backend/accounts/templates/accounts/profile.html
+++ b/backend/accounts/templates/accounts/profile.html
@@ -220,7 +220,7 @@
 
         <div>
           <label for="{{ account_form.first_name.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Nombre</label>
-          {{ account_form.first_name.as_widget(attrs={"data-modal-focus": "true"}) }}
+          {{ account_form.first_name.as_widget(attrs={'data-modal-focus': 'true'}) }}
           {% if account_form.first_name.errors %}
             <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ account_form.first_name.errors|striptags }}</small>
           {% endif %}
@@ -285,7 +285,7 @@
 
         <div>
           <label for="{{ password_form.old_password.id_for_label }}" style="display: block; font-weight: 600; margin-bottom: 0.4rem;">Contraseña actual</label>
-          {{ password_form.old_password.as_widget(attrs={"data-modal-focus": "true"}) }}
+          {{ password_form.old_password.as_widget(attrs={'data-modal-focus': 'true'}) }}
           {% if password_form.old_password.errors %}
             <small style="color: #b91c1c; display: block; margin-top: 0.35rem;">{{ password_form.old_password.errors|striptags }}</small>
           {% endif %}

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,8 +1,9 @@
 from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 
-from .forms import CompanyProfileForm
+from .forms import CompanyProfileForm, StyledPasswordChangeForm, UserAccountForm
 from .models import CompanyProfile
 
 
@@ -13,12 +14,46 @@ def profile(request):
     profile, _ = CompanyProfile.objects.get_or_create(user=request.user)
 
     if request.method == "POST":
-        form = CompanyProfileForm(request.POST, request.FILES, instance=profile)
-        if form.is_valid():
-            form.save()
-            messages.success(request, "Datos fiscales actualizados correctamente.")
-            return redirect("accounts:profile")
-    else:
-        form = CompanyProfileForm(instance=profile)
+        if request.POST.get("action") == "update-account":
+            account_form = UserAccountForm(request.POST, instance=request.user)
+            password_form = StyledPasswordChangeForm(user=request.user)
+            profile_form = CompanyProfileForm(instance=profile)
 
-    return render(request, "accounts/profile.html", {"form": form, "profile": profile})
+            if account_form.is_valid():
+                account_form.save()
+                messages.success(request, "Información de cuenta actualizada correctamente.")
+                return redirect("accounts:profile")
+        elif request.POST.get("action") == "change-password":
+            account_form = UserAccountForm(instance=request.user)
+            password_form = StyledPasswordChangeForm(user=request.user, data=request.POST)
+            profile_form = CompanyProfileForm(instance=profile)
+
+            if password_form.is_valid():
+                user = password_form.save()
+                update_session_auth_hash(request, user)
+                messages.success(request, "Contraseña actualizada correctamente.")
+                return redirect("accounts:profile")
+        else:
+            account_form = UserAccountForm(instance=request.user)
+            password_form = StyledPasswordChangeForm(user=request.user)
+            profile_form = CompanyProfileForm(request.POST, request.FILES, instance=profile)
+
+            if profile_form.is_valid():
+                profile_form.save()
+                messages.success(request, "Datos fiscales actualizados correctamente.")
+                return redirect("accounts:profile")
+    else:
+        account_form = UserAccountForm(instance=request.user)
+        password_form = StyledPasswordChangeForm(user=request.user)
+        profile_form = CompanyProfileForm(instance=profile)
+
+    return render(
+        request,
+        "accounts/profile.html",
+        {
+            "account_form": account_form,
+            "password_form": password_form,
+            "profile_form": profile_form,
+            "profile": profile,
+        },
+    )


### PR DESCRIPTION
## Summary
- add reusable styled forms for updating personal information and passwords
- update the profile view to handle account, password, and company profile submissions with success messaging
- refresh the profile template to expose account and password management while keeping the username read-only

## Testing
- python backend/manage.py test *(fails: database NAME is not configured for test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68efc7d366b48320b37bcb8e0bc731e0